### PR TITLE
Serve frontend with Node backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 
 
 ```bash
-node server.js
+npm start
 ```
 
-The server stores data in the `data/` directory using JSON files. Endpoints include:
+The server stores data in the `data/` directory using JSON files. The server also serves the frontend from `/frontend`, so visiting `http://localhost:3000` loads the React app.
+Endpoints include:
 
 - `GET /stadiums` – list stadiums
 - `POST /stadiums` – create a stadium

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const path = require('path');
 const DATA_DIR = path.join(__dirname, 'data');
 const STADIUMS_FILE = path.join(DATA_DIR, 'stadiums.json');
 const MEALS_FILE = path.join(DATA_DIR, 'meals.json');
+const FRONTEND_DIR = path.join(__dirname, 'frontend');
 
 function ensureDataFiles() {
   if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR);
@@ -97,6 +98,21 @@ function router(req, res) {
   }
   if (req.method === 'POST' && req.url.startsWith('/meals')) {
     return createMeal(req, res);
+  }
+  // serve static files from the frontend directory
+  if (req.method === 'GET') {
+    const reqPath = req.url === '/' ? '/index.html' : req.url;
+    const filePath = path.join(FRONTEND_DIR, reqPath);
+    if (fs.existsSync(filePath)) {
+      const ext = path.extname(filePath).toLowerCase();
+      let contentType = 'text/plain';
+      if (ext === '.html') contentType = 'text/html';
+      else if (ext === '.css') contentType = 'text/css';
+      else if (ext === '.js') contentType = 'text/javascript';
+      const fileContent = fs.readFileSync(filePath);
+      res.writeHead(200, { 'Content-Type': contentType });
+      return res.end(fileContent);
+    }
   }
   res.writeHead(404);
   res.end('Not Found');


### PR DESCRIPTION
## Summary
- serve static files from `frontend/` in `server.js`
- expose an npm `start` script
- document new startup method and clarify the server now hosts the frontend

## Testing
- `npm test` *(fails: no test specified)*
- `npm start`